### PR TITLE
Updated release workflow trigger and push method

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   release:
@@ -57,12 +56,14 @@ jobs:
         run: conventional-changelog -p angular -i CHANGELOG.md -s
   
       - name: Commit changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add CHANGELOG.md
           git commit -m 'chore(release): update changelog'
-          git push origin HEAD:main
+          git push origin HEAD:main --force
 
       - name: Create release artifact (zip)
         run: |


### PR DESCRIPTION
The release workflow has been updated to be manually triggered instead of being automatically triggered on release creation. Additionally, the 'git push' command now uses the '--force' option. The GITHUB_TOKEN environment variable was also added for authentication during commit changelog step.
