### PR TITLE
Updated GitHub workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -44,25 +46,6 @@ jobs:
       - name: Publish macOS
         run: dotnet publish src/2048Game/2048Game.csproj --configuration Release --output ./output/osx-arm64 --self-contained --runtime osx-arm64
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-        
-      - name: Install conventional-changelog-cli
-        run: npm install -g conventional-changelog-cli
-
-      - name: Generate changelog
-        run: conventional-changelog -p angular -i CHANGELOG.md -s
-  
-      - name: Commit changelog
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add CHANGELOG.md
-          git commit -m 'chore(release): update changelog'
-          git push origin HEAD:main
-
       - name: Create release artifact (zip)
         run: |
           zip -r 2048Game-win-x86.zip ./output/win-x86
@@ -78,4 +61,5 @@ jobs:
             ./2048Game-osx-arm64.zip
           tag_name: v${{ env.GitVersion_SemVer }}
           name: Release v${{ env.GitVersion_SemVer }}
-          body_path: CHANGELOG.md
+          generate_release_notes: true
+          make_latest: true


### PR DESCRIPTION
Added write permissions to the release job in the GitHub workflow. Removed steps related to Node.js setup, changelog generation and commit. Instead, enabled automatic release notes generation and set the latest release as default.
